### PR TITLE
GIFT-128 Block Cipher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+CXX = g++
+CXXFLAGS = -std=c++20 -Wall -Wextra -pedantic
+OPTFLAGS = -O3
+IFLAGS = -I ./include
+
+all: benchmark
+
+clean:
+	find . -name '*.out' -o -name '*.o' -o -name '*.so' -o -name '*.gch' | xargs rm -rf
+
+format:
+	find . -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i --style=Mozilla
+
+bench/a.out: bench/main.cpp include/*.hpp
+	# make sure you've google-benchmark globally installed;
+	# see https://github.com/google/benchmark/tree/60b16f1#installation
+	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $< -lbenchmark -o $@
+
+benchmark: bench/a.out
+	./$<

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -1,0 +1,7 @@
+#include "bench_gift.hpp"
+
+// register gift-128 for benchmarking
+BENCHMARK(bench_gift_cofb::gift_permute);
+
+// benchmark runner main function
+BENCHMARK_MAIN();

--- a/include/bench_gift.hpp
+++ b/include/bench_gift.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#include "gift.hpp"
+#include "utils.hpp"
+#include <benchmark/benchmark.h>
+
+// Benchmark GIFT-COFB Authenticated Encryption on CPU
+namespace bench_gift_cofb {
+
+// Benchmark GIFT-128 permutation ( 40 -rounds ) on CPU, by generating 128 -bit
+// random plain text and secret key
+static void
+gift_permute(benchmark::State& state)
+{
+  constexpr size_t N = 16;
+
+  uint8_t* txt = static_cast<uint8_t*>(std::malloc(N));
+  uint8_t* key = static_cast<uint8_t*>(std::malloc(N));
+
+  random_data(txt, N);
+  random_data(key, N);
+
+  gift::state_t st;
+  gift::initialize(&st, txt, key);
+
+  for (auto _ : state) {
+    gift::permute(&st);
+
+    benchmark::DoNotOptimize(st);
+    benchmark::ClobberMemory();
+  }
+
+  state.SetBytesProcessed(static_cast<int64_t>(N * state.iterations()));
+
+  std::free(txt);
+  std::free(key);
+}
+
+}

--- a/include/gift.hpp
+++ b/include/gift.hpp
@@ -1,7 +1,9 @@
 #pragma once
 #include <algorithm>
+#include <bit>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 
 // GIFT-128 Block Cipher
 namespace gift {
@@ -156,6 +158,23 @@ add_round_keys(state_t* const st, const size_t r_idx)
   st->cipher[1] ^= v;
 
   st->cipher[3] ^= (1u << 31) | static_cast<uint32_t>(RC[r_idx]);
+}
+
+// GIFT-128 key state updation function, as defined in top of page 7 of
+// GIFT-COFB specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/gift-cofb-spec-final.pdf
+inline static void
+update_key_state(state_t* const st)
+{
+  const uint16_t t0 = std::rotr(st->key[6], 2);
+  const uint16_t t1 = std::rotr(st->key[7], 12);
+
+  uint16_t tmp[6];
+  std::memcpy(tmp, st->key, sizeof(tmp));
+  std::memcpy(st->key + 2, tmp, sizeof(tmp));
+
+  st->key[0] = t0;
+  st->key[1] = t1;
 }
 
 }

--- a/include/gift.hpp
+++ b/include/gift.hpp
@@ -6,6 +6,34 @@
 // GIFT-128 Block Cipher
 namespace gift {
 
+// 32 -bit bit permutation, applied to S0 word of cipher state, as listed in
+// table 2.2 of GIFT-COFB specification
+constexpr uint32_t BIT_PERM_S0[32] = { 0, 4, 8,  12, 16, 20, 24, 28,
+                                       3, 7, 11, 15, 19, 23, 27, 31,
+                                       2, 6, 10, 14, 18, 22, 26, 30,
+                                       1, 5, 9,  13, 17, 21, 25, 29 };
+
+// 32 -bit bit permutation, applied to S1 word of cipher state, as listed in
+// table 2.2 of GIFT-COFB specification
+constexpr uint32_t BIT_PERM_S1[32] = { 1, 5, 9,  13, 17, 21, 25, 29,
+                                       0, 4, 8,  12, 16, 20, 24, 28,
+                                       3, 7, 11, 15, 19, 23, 27, 31,
+                                       2, 6, 10, 14, 18, 22, 26, 30 };
+
+// 32 -bit bit permutation, applied to S2 word of cipher state, as listed in
+// table 2.2 of GIFT-COFB specification
+constexpr uint32_t BIT_PERM_S2[32] = { 2, 6, 10, 14, 18, 22, 26, 30,
+                                       1, 5, 9,  13, 17, 21, 25, 29,
+                                       0, 4, 8,  12, 16, 20, 24, 28,
+                                       3, 7, 11, 15, 19, 23, 27, 31 };
+
+// 32 -bit bit permutation, applied to S3 word of cipher state, as listed in
+// table 2.2 of GIFT-COFB specification
+constexpr uint32_t BIT_PERM_S3[32] = { 3, 7, 11, 15, 19, 23, 27, 31,
+                                       2, 6, 10, 14, 18, 22, 26, 30,
+                                       1, 5, 9,  13, 17, 21, 25, 29,
+                                       0, 4, 8,  12, 16, 20, 24, 28 };
+
 // GIFT-128 block cipher state, as defined in section 2.4.1 of GIFT-COFB
 // specification ( see page 5 )
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/gift-cofb-spec-final.pdf
@@ -64,6 +92,34 @@ subcells(state_t* const st)
   st->cipher[2] ^= t3;
 
   std::swap(st->cipher[0], st->cipher[3]);
+}
+
+// Permutes 32 -bits of a word of cipher state of GIFT-128 block cipher (
+// invoked as part of PermBits step )
+inline static uint32_t
+permword(const uint32_t w, const uint32_t* const bit_perm)
+{
+  uint32_t tmp = 0u;
+
+  for (size_t i = 0; i < 32; i++) {
+    tmp |= ((w >> i) & 0b1u) << bit_perm[i];
+  }
+
+  return tmp;
+}
+
+// Four different 32 -bit bit permutations are independently applied on each
+// word of cipher state of GIFT-128 block cipher
+//
+// See PermBits specification defined in page 6 of GIFT-COFB specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/gift-cofb-spec-final.pdf
+inline static void
+permbits(state_t* const st)
+{
+  st->cipher[0] = permword(st->cipher[0], BIT_PERM_S0);
+  st->cipher[1] = permword(st->cipher[1], BIT_PERM_S1);
+  st->cipher[2] = permword(st->cipher[2], BIT_PERM_S2);
+  st->cipher[3] = permword(st->cipher[3], BIT_PERM_S3);
 }
 
 }

--- a/include/gift.hpp
+++ b/include/gift.hpp
@@ -177,4 +177,35 @@ update_key_state(state_t* const st)
   st->key[1] = t1;
 }
 
+// GIFT-128 round function, consisting of three sequential steps
+//
+// i) substitute cells
+// ii) permute bits
+// iii) add round keys and round constants
+//
+// See section 2.4.1 of GIFT-COFB specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/gift-cofb-spec-final.pdf
+inline static void
+round(state_t* const st, const size_t r_idx)
+{
+  sub_cells(st);
+  perm_bits(st);
+  add_round_keys(st, r_idx);
+
+  update_key_state(st);
+}
+
+// GIFT-128 substitution permutation network ( SPN ) block cipher, operating on
+// initialized cipher/ key state, by applying 40 iterative rounds of GIFT-128
+//
+// See section 2.4.1 of GIFT-COFB specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/gift-cofb-spec-final.pdf
+inline static void
+permute(state_t* const st)
+{
+  for (size_t i = 0; i < ROUNDS; i++) {
+    round(st, i);
+  }
+}
+
 }

--- a/include/gift.hpp
+++ b/include/gift.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 
@@ -18,7 +19,7 @@ struct state_t
 // key, as defined in section 2.4.2 of GIFT-COFB specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/gift-cofb-spec-final.pdf
 inline static void
-initialize(state_t* const st,                   // GIFT-128 block cipher state
+initialize(state_t* const __restrict st,        // GIFT-128 block cipher state
            const uint8_t* const __restrict txt, // 128 -bit plain text block
            const uint8_t* const __restrict key  // 128 -bit secret key
 )
@@ -38,6 +39,31 @@ initialize(state_t* const st,                   // GIFT-128 block cipher state
     st->key[i] = (static_cast<uint16_t>(key[boff ^ 0]) << 8) |
                  (static_cast<uint16_t>(key[boff ^ 1]) << 0);
   }
+}
+
+// Substitutes cells of cipher state with following instructions, as defined in
+// page 5 of GIFT-COFB specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/gift-cofb-spec-final.pdf
+inline static void
+subcells(state_t* const st)
+{
+  const uint32_t t0 = st->cipher[0] & st->cipher[2];
+  st->cipher[1] ^= t0;
+
+  const uint32_t t1 = st->cipher[1] & st->cipher[3];
+  st->cipher[0] ^= t1;
+
+  const uint32_t t2 = st->cipher[0] | st->cipher[1];
+  st->cipher[2] ^= t2;
+
+  st->cipher[3] ^= st->cipher[2];
+  st->cipher[1] ^= st->cipher[3];
+  st->cipher[3] = ~st->cipher[3];
+
+  const uint32_t t3 = st->cipher[0] & st->cipher[1];
+  st->cipher[2] ^= t3;
+
+  std::swap(st->cipher[0], st->cipher[3]);
 }
 
 }

--- a/include/gift.hpp
+++ b/include/gift.hpp
@@ -119,7 +119,7 @@ perm_word(const uint32_t w, const uint32_t* const bit_perm)
   uint32_t tmp = 0u;
 
   for (size_t i = 0; i < 32; i++) {
-    tmp |= ((w >> i) & 0b1u) << bit_perm[i];
+    tmp |= ((w >> bit_perm[i]) & 0b1u) << i;
   }
 
   return tmp;

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -2,6 +2,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <iomanip>
+#include <random>
 #include <sstream>
 
 // Given a bytearray of length N, this function converts it to human readable
@@ -17,4 +18,17 @@ to_hex(const uint8_t* const bytes, const size_t len)
   }
 
   return ss.str();
+}
+
+// Generates N -many random bytes | N >= 0
+static inline void
+random_data(uint8_t* const data, const size_t len)
+{
+  std::random_device rd;
+  std::mt19937_64 gen(rd());
+  std::uniform_int_distribution<uint8_t> dis;
+
+  for (size_t i = 0; i < len; i++) {
+    data[i] = dis(gen);
+  }
 }

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -1,0 +1,20 @@
+#pragma once
+#include <cstddef>
+#include <cstdint>
+#include <iomanip>
+#include <sstream>
+
+// Given a bytearray of length N, this function converts it to human readable
+// hex string of length N << 1
+static inline const std::string
+to_hex(const uint8_t* const bytes, const size_t len)
+{
+  std::stringstream ss;
+  ss << std::hex;
+
+  for (size_t i = 0; i < len; i++) {
+    ss << std::setw(2) << std::setfill('0') << static_cast<uint32_t>(bytes[i]);
+  }
+
+  return ss.str();
+}


### PR DESCRIPTION
- [x] Implement GIFT-128 block cipher
- [x] Test functional correctness of block cipher, using provided test vectors
- [x] Benchmark GIFT-128 on CPU

See section 2.4 of [GIFT-COFB](https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/gift-cofb-spec-final.pdf) specification for details on how GIFT-128 block cipher works. 