### PR TITLE
Never Release Unverified Plain Text (RUP)

### DIFF
--- a/include/aead.hpp
+++ b/include/aead.hpp
@@ -541,6 +541,7 @@ decrypt(const uint8_t* const __restrict key,   // 128 -bit key
     flg |= static_cast<bool>(tag[i] ^ tag_[i]);
   }
 
+  std::memset(txt, 0, flg * ctlen);
   return !flg;
 }
 


### PR DESCRIPTION
- [x] Don't release unverified plain text if authentication failure is encountered during decryption
- [x] Explicitly zero out memory allocation which should hold decrypted plain text bytes
- [x] Add test cases asserting above 